### PR TITLE
ci: nextest・カバレッジゲート・zizmor で workflow を強化

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,9 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+# Default 60s is too tight for cold CI runs; allow 2 grace periods before killing (max 240s).
+slow-timeout = { period = "120s", terminate-after = 2 }
+# Surface flaky tests in the final report so retries don't hide intermittent failures.
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
@@ -29,17 +31,87 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-nextest
+
       - name: Check
         run: cargo check
 
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
       - name: Clippy
         run: cargo clippy -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check
+
+  coverage:
+    # Coverage delta gate: fail when project line coverage (C0) drops vs main.
+    # Measures base-vs-head total C0 rather than diff-cover changed-lines: a
+    # move-only refactor relocates already-tested lines, which diff-cover reads
+    # as "new and uncovered" on the added side even though total coverage is
+    # unchanged. Base-vs-head total C0 is move-immune (relocated lines cancel),
+    # while genuinely new untested code still lowers the total and fails. No
+    # absolute floor, so pre-existing unreachable code is never flagged.
+    # No --ignore-filename-regex excludes: shields keeps all tests inline as
+    # `#[cfg(test)] mod tests {}` (no separate tests.rs to skew the denominator)
+    # and has no network-IO module whose coverage flickers run-to-run. Add an
+    # exclude only if CI shows a file's coverage is nondeterministic.
+    # Runs on ubuntu like the test job.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Coverage delta gate (project C0 must not drop vs main)
+        run: |
+          set -euo pipefail
+          # Sum LH (lines hit) / LF (lines found) across an lcov report -> C0 %.
+          c0() { awk -F: '/^LF:/{f+=$2} /^LH:/{h+=$2} END{ if (f==0) print "100.0"; else printf "%.4f", h*100/f }' "$1"; }
+          # HEAD = PR merged into main (the checked-out pull_request ref).
+          # cargo llvm-cov cleans stale profraw at the start of each run, so the
+          # two measurements below do not mix.
+          cargo llvm-cov --lcov --output-path head.info
+          head_c0=$(c0 head.info)
+          # BASE = main (fetch-depth:0 already has the history).
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git checkout --quiet --force origin/main
+          cargo llvm-cov --lcov --output-path base.info
+          base_c0=$(c0 base.info)
+          # 0.1pp tolerance absorbs instrumentation rounding / total line drift.
+          awk -v b="$base_c0" -v h="$head_c0" 'BEGIN {
+            printf "C0 coverage: main %.2f%% -> PR %.2f%%\n", b, h
+            if (h + 0.1 < b) {
+              printf "::error::C0 coverage dropped %.2f%% -> %.2f%% (tolerance 0.1pp)\n", b, h
+              exit 1
+            }
+            print "OK: coverage did not drop"
+          }'
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -48,6 +120,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install nextest
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
@@ -74,13 +74,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
           components: llvm-tools-preview
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
@@ -124,12 +124,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-targets: false
 

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply priority labels
-        uses: stefanbuck/[email protected]
+        uses: stefanbuck/github-issue-parser@6cfd00ce86eed290cdcbfdf625720282dc3ed90a # v2.0.0
         with:
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
+        uses: stefanbuck/github-issue-parser@6cfd00ce86eed290cdcbfdf625720282dc3ed90a # v2.0.0
         with:
           template: feature.yml
           section: priority

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,17 @@
+rules:
+  artipacked:
+    ignore:
+      # update-homebrew job requires HOMEBREW_TAP_TOKEN to be persisted for git push
+      - release.yml:122
+      # update-sentinels job requires SENTINELS_TOKEN to be persisted for git push
+      - release.yml:183
+  cache-poisoning:
+    ignore:
+      # Swatinem/rust-cache in build job; release workflow runs on tag push only,
+      # no PR-driven cache injection path exists for poisoning to reach release artifacts
+      - release.yml:47
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release retained for generate_release_notes feature
+      # which gh CLI does not provide equivalently in script step
+      - release.yml:109

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ docs/
 target/
 workspace/
 review-report.md
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/lcov.info
+/head.info
+/base.info


### PR DESCRIPTION
CI 強化 3 件を 1 本にまとめた。いずれも `ci.yml` を編集するため分割すると衝突するのと、zizmor が他 workflow に出す findings も同時に解消するため。

## 対応 issue

- Closes #16 — `cargo test` → `cargo nextest run --profile ci`。`.config/nextest.toml` 追加 (fail-fast off / slow-timeout 120s×2 / flaky を最終レポートに表示)。doctest step は無し (shields は lib target を持たないバイナリ crate、`cargo test --doc` は "no library targets" で対象ゼロを確認)
- Closes #19 — PR 限定の `coverage` job 追加。**base-vs-head 総 C0 が main より下がると fail**。issue 文言の diff-cover ではなく guardrails が移動リファクタでの誤検知を経て到達した総 C0 方式を採用 (move-only PR に強い)。除外なし: shields のテストは全て inline `#[cfg(test)]` で tests.rs 分離が無く、coverage が run 毎に揺れる network-IO モジュールも無い
- Closes #15 — `zizmor.yml` workflow 追加、`label-from-issue.yml` の stefanbuck action を SHA pin、token 不要な checkout に `persist-credentials: false`、release.yml の回避不能な 4 findings を `.github/zizmor.yml` で justification 付き ignore (token push checkout ×2 / tag 限定 cache / gh-release notes)

## 検証

- `zizmor .github/workflows/` → `No findings to report` (4 ignored, 22 suppressed)
- `actionlint` → clean (exit 0)
- coverage job のローカル実測は作業ツリーの別問題 (`src/check/secrets.rs` が root 所有 0 バイトで破損、要手動復旧) によりビルド不能のためスキップ。CI 上で C0 が非決定的に揺れる場合は該当ファイルを `--ignore-filename-regex` に追加する運用

https://claude.ai/code/session_01DUHaaztegmkAQ6vREXgQxb