### PR TITLE
ci: dependabot を有効化 (github-actions と cargo)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
依存の自動更新 PR を受け取るため `.github/dependabot.yml` を追加。

- `github-actions` と `cargo` の 2 ecosystem を weekly 監視
- cargo の minor/patch は 1 PR にグルーピング (major は個別)
- ラベル `dependencies` / `ci` / `rust` を付与 (3 ラベルとも repo に既存を確認済み)

Closes #8

https://claude.ai/code/session_01DUHaaztegmkAQ6vREXgQxb